### PR TITLE
✏️ fix typo for pydantic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pyside6
 pyqtgraph
 pyopengl
-pydyantic
+pydantic
 tqdm
 opencv-python
 matplotlib


### PR DESCRIPTION
HI, there was an error while running the command:

`python3 -m pip install -r requirements.txt`

in the original project.

And the reason was a typo in the requirement, so I've done the fix.